### PR TITLE
fix: Swagger UI request URL

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -32,7 +32,7 @@ const options = {
 		},
 		servers: [
 			{
-				url: "http://localhost:3000",
+				url: "http://localhost:4000",
 			},
 		],
 	},


### PR DESCRIPTION
The request URL for Swagger UI should be `http://localhost:4000` like shown in the video, instead of `http://localhost:3000` that results in a "404 Error: Not Found" response when executing queries.