### PR TITLE
Rename onFormSubmit parameter to avoid name collision

### DIFF
--- a/client/src/UpdateBook/UpdateBook.jsx
+++ b/client/src/UpdateBook/UpdateBook.jsx
@@ -11,8 +11,8 @@ export const UpdateBook = () => {
   const { data, error, isLoading, isError } = useQuery(["book", { id }], getBook);
   const { mutateAsync, isLoading: isMutating } = useMutation(updateBook)
 
-  const onFormSubmit = async (data) => {
-    await mutateAsync({...data, id})
+  const onFormSubmit = async (formData) => {
+    await mutateAsync({...formData, id})
     history.push("/")
   }
 


### PR DESCRIPTION
Just a small rename of the parameter since `data` is already used in the useQuery destructuring in the same function's scope.